### PR TITLE
Fix compatibility with newer Samsung Health export schema (2024+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,48 @@
 # FromSamToGarm - Migrate from Samsung Health to Garmin Connect
 
-
 ## What is this?
-
 This is a collection of three scripts that allow you to move some of your data from Samsung Health to Garmin Connect.
 
+This fork updates the original scripts to be compatible with newer Samsung Health export formats (tested with exports from 2025–2026). See the [Compatibility Notes](#compatibility-notes) section for details on what changed.
+
+---
 
 ## Preparation
-
 First, you have to export your whole Samsung Health data via the app. Copy everything into a folder on your computer.
 
-Next, you will need to have a recent version of Python installed on your computer. A recent version of the lxml package is also needed.
+Next, you will need a recent version of **Python** installed on your computer, as well as the **lxml** package. You can install it with:
 
-Finally, you download the three scripts and copy them into the folder where you have your Samsung Health data.
+```bash
+pip install lxml
+```
+
+Finally, download the three scripts and copy them into the folder where you have your Samsung Health data (the folder containing the `.csv` files).
 
 Please check your operating system's documentation to find out how to install Python and how to run scripts.
 
+---
 
 ## Warning
-
 You might want to open a clean test account on Garmin Connect and test the scripts first, because there is currently no way to efficiently delete multiple activities at once. If you mess up your pre-existing data, it will be a lot of work to clean things up...
 
+---
 
 ## Importing weight data
-
 You can import data on your weight, height and BMI from Samsung Health.
 
 1. Run the `weight.py` script. It should automatically find the file containing the weight data from Samsung Health. It will convert the data and create one or more files in the same folder. Those files are called `weight-export-XX.csv` with XX being a number.
 2. Go to the Garmin Connect web portal and click the "Upload or Import Activity" icon in the upper right corner. Choose "Import Data".
 3. Find the `weight-export-XX.csv` files created by the script. Drag and drop them into the drop zone.
-4. Click "Import Data". The script will prepare the data in metric units, so you will have to set "Length Units" and "Weight Units" accordingly, even if you normally use British or American units. Garmin Connect will convert the data for you.
+4. Click "Import Data". Garmin may detect the file as "Fitbit® Data" — this is expected and will import correctly. The script prepares data in metric units, so set "Length Units" and "Weight Units" to metric accordingly, even if you normally use British or American units. Garmin Connect will convert the data for you.
 5. Click "Continue" and wait for the magic to happen.
 
-Note: You can import your data several times. In this case, existing values will be overwritten.
+**Note:** You can import your data several times. In this case, existing values will be overwritten.
 
+**Note:** Some weight entries may not have a height value recorded (common when weight was logged by a third-party app like MyFitnessPal). The script handles this by carrying forward the last known height value to calculate BMI.
+
+---
 
 ## Importing general activity data
-
 You can import data on calories burned (resting and active), steps, distance, floors climbed and intensity minutes. Please note that the way Samsung Health records activity minutes differs from the way Garmin records and counts intensity minutes.
 
 1. Run the `activity.py` script. It should automatically find the files containing the relevant data from Samsung Health. It will convert the data and create one or more files in the same folder. Those files are called `activities-export-XX.csv` with XX being a number.
@@ -45,38 +51,66 @@ You can import data on calories burned (resting and active), steps, distance, fl
 4. Click "Import Data". The script will prepare the data in metric units, so you will have to set "Length Units" and "Weight Units" accordingly, even if you normally use British or American units. Garmin Connect will convert the data for you.
 5. Click "Continue" and wait for the magic to happen.
 
-Note: There might be some error messages, in extreme casese for the majority of files. Most of the time the import still works. Just check your statistics by clicking "Activities" and then "Steps" in the main navigation. In the "Steps" card, click the "Reports" icon and click on "1 Year". This should make it easy enough for you to check whether the data is plausible. Do this for the floors climbed and calories as well. If you do it for the intensity minutes, please remember what was said above: there will probably be a major difference between Samsung Health and Garmin Connect, because Garmin's intensity minutes are not counted in the same way as Samsung's active minutes.
+**Note:** There might be some error messages, in extreme cases for the majority of files. This is often a transient issue with Garmin's importer — retrying the failed files usually works. The import itself is generally successful even when errors are shown.
 
-In case of problems, you can import your data several times. Steps, floors, calories and minutes will not be cumulated in this case. Instead, the most recent import will overwrite existing data.
+To verify your data imported correctly: click "Activities" → "Steps" in the main navigation, click the "Reports" icon in the Steps card, and select "1 Year". Do the same for floors climbed and calories. For intensity minutes, expect a significant difference between Samsung Health and Garmin Connect, as they count active minutes differently.
 
+In case of problems, you can import your data several times. Steps, floors, calories and minutes will not be cumulated — the most recent import will overwrite existing data.
+
+---
 
 ## Importing activities and exercises
+You can import recorded activities, e.g. runs or bike rides. Please note that the import is not perfect, but many things work fine, including duration, GPS data, heart rate, and calories burned.
 
-You can import recorded activities, e.g. runs or bike rides. Please note that the import is not perfect, but many things work fine, including duration of the activity and the calories burned.
+**Note:** While Garmin Connect offers a wide range of activity types, the TCX (Training Center Database File) standard only allows three types: Running, Biking and Other. You will probably have to manually adjust the activity type after importing. Samsung activity type codes are used in the filename (e.g. `1002` = running, `1001` = walking, `11007` = cycling, `13001` = hiking) to make bulk re-typing easier.
 
-Please note: While Garmin Connect offers a vide range of activity types, the TCX (Training Center Database File) standard only allows three types: Running, Biking and Other. This means that you will probably have to manually adjust the type of your activities once they are imported.
-
-1. Run the `exercises.py` script. It should automatically find the files containing the relevant data from Samsung Health. It will convert the data and create a whole bunch of TCX files (one for every recorded activity) in a subfolder called `exports`. This subfolder will be created, if it does not exist.
+1. Run the `exercises.py` script. It should automatically find the files containing the relevant data from Samsung Health. It will convert the data and create a TCX file for every recorded activity in a subfolder called `exports`. This subfolder will be created if it does not exist.
 2. Go to the Garmin Connect web portal and click the "Upload or Import Activity" icon in the upper right corner. Choose "Import Data".
-3. Go to the `exports` folder created by the script. Drag and drop as many files as you wish into the drop zone. (You should probably not take more than one hundred at a time.)
-4. Click "Import Data". The script will prepare the data in metric units, so you will have to set "Length Units" and "Weight Units" accordingly, even if you normally use British or American units. Garmin Connect will convert the data for you.
+3. Go to the `exports` folder. Drag and drop files into the drop zone. Aim for batches of around 100 at a time.
+4. Click "Import Data". Set units to metric as described above.
 5. Click "Continue" and wait for the magic to happen.
 
-The created TCX files' name always starts with Samsung's activity type, e.g. 1001 for walking or 13001 for hiking. Importing them grouped by type will make it easier for you to adjust the activity type in Garmin Connect, because after the import, you can open all imported activities' details (in new tabs).
+**Tip:** Import files grouped by activity type prefix (e.g. all `1002_*` runs together) — this makes it easier to bulk-update the activity type in Garmin Connect after importing.
 
-Also, it might be best to import the files by group, e.g. all files starting with `0`, all with `1` etc. This will make it easier for you to know what is done and what is not. In any case, Garmin Connect will check whether an activity has already been imported and will not import it a second time.
+**Tip:** Garmin Connect will detect and skip duplicate uploads, so it is safe to re-run batches that had errors.
 
+---
 
 ## Importing sleep data
-
 Sorry, you cannot import sleep data.
 
+---
+
+## Compatibility Notes
+
+This fork was updated to handle Samsung Health export schema changes introduced in newer app versions. If you are using a **2024 or later Samsung Health export**, you may encounter issues with the original scripts. The following changes were made:
+
+### `exercises.py`
+- The glob pattern was updated from `com.samsung.shealth.exercise.*.csv` to `com.samsung.shealth.exercise.20*.csv` to avoid accidentally matching sub-files such as `hr_zone`, `extension`, `weather`, and `periodization_training_schedule`, which share the same prefix.
+- In newer exports, `datauuid` and `start_time` in the exercise file use the full `com.samsung.health.exercise.` column prefix. The field mapping was updated accordingly.
+- `total_calorie` and `heart_rate_sample_count` remain unprefixed bare column names.
+- The exercise CSV is encoded with a UTF-8 BOM; the file is now opened with `utf-8-sig` encoding to handle this correctly.
+- The `live_data` and `location_data` fields now contain JSON filenames rather than `0`/`1` flags. The script was updated to detect presence by checking for a non-empty, non-`"0"` value.
+
+### `activity.py`
+- In newer exports, the `day_time` field in `com.samsung.shealth.activity.day_summary` is a human-readable datetime string (e.g. `2026-01-30 00:00:00.000`) rather than a Unix millisecond timestamp. The script now handles both formats.
+- A bug in `merge_data` where dates present in the floors data but not the calories data would cause a `KeyError` has been fixed.
+- Missing `Floors` values (empty strings) are now defaulted to `0` before writing, preventing import failures in Garmin Connect.
+
+### `weight.py`
+- Some weight entries have an empty `height` field (common for entries logged by third-party apps). The script now carries forward the last known height value and skips rows with no weight recorded, rather than crashing.
+
+---
 
 ## Bugs and improvements
-
 Feel free to open an issue or create a pull request on GitHub.
 
+---
 
 ## Known Problems
 
-- Sometimes, Garmin Connect will show negative calories for certain days, especially days where no exercise is recorded. A simple (but maybe tedious) way to fix this, is to create a manual activity with 0 calories for the day in question. This will trigger a recalculation. Once that is done, you can either delete the activity or edit it in order to set the date to the next problematic day.
+- **Negative calories:** Sometimes Garmin Connect will show negative calories for certain days, especially days where no exercise is recorded. A simple fix is to create a manual activity with 0 calories for the affected day — this triggers a recalculation. Once done, you can delete or repurpose the activity for the next affected day.
+
+- **Transient upload errors:** Garmin Connect's importer occasionally returns errors on individual files even when the data is valid. Simply retry the failed files — they usually succeed on the second or third attempt.
+
+- **Activity type labels:** All imported exercises default to "Running", "Biking", or "Other" due to TCX format limitations. Use the Samsung activity type code in the filename to identify and bulk-update activity types in Garmin Connect after importing.

--- a/activity.py
+++ b/activity.py
@@ -63,35 +63,32 @@ def fetch_calorie_data():
 
 
 def fetch_activity_data():
-    """
-    Fetch the activity data.
-    """
-
     activity_files = glob.glob("com.samsung.shealth.activity.day_summary.*.csv")
     if len(activity_files) == 0:
         raise Exception("No activity data found.")
     filename = activity_files[0]
 
     with open(filename, newline="") as activity_data:
-        # Skip first line
         next(activity_data)
         reader = csv.DictReader(activity_data)
         activity_data = {}
         for row in reader:
-            date = datetime.datetime.fromtimestamp(
-                int(row["day_time"]) / 1000
-            ).strftime("%Y-%m-%d")
+            # Handle both Unix ms timestamps and human-readable datetime strings
+            raw = row["day_time"].strip()
+            try:
+                date = datetime.datetime.fromtimestamp(int(raw) / 1000).strftime("%Y-%m-%d")
+            except ValueError:
+                date = raw[0:10]
+
             step_count = int(row["step_count"])
-            # Samsung Health stores the distance in m, Garmin Connect expects it to be in km.
             distance = round(float(row["distance"]) / 1000, 2)
             calorie = float(row["calorie"])
-            # Times are stored in milliseconds.
             run_time = int(row["run_time"]) / 60000
             walk_time = int(row["walk_time"]) / 60000
             activity_data[date] = {
                 "Steps": step_count,
                 "Distance": distance,
-                "Minutes Sedentary": 0,  # We set this to zero, because Garmin won't show it anyway.
+                "Minutes Sedentary": 0,
                 "Minutes Lightly Active": int(walk_time),
                 "Minutes Fairly Active": 0,
                 "Minutes Very Active": int(run_time),
@@ -109,13 +106,10 @@ def merge_data(floors, calories, activities):
 
     for date, f in floors.items():
         if date not in merged_data:
-            merged_data[date]["Calories"] = 0
+            merged_data[date] = {"Calories Burned": 0}  # was missing, create entry first
         merged_data[date]["Floors"] = f
 
     for date, dic in activities.items():
-        # If no steps have been recorded for a given date, we can drop that entry entirely,
-        # because that means other data will not be useful anyway: no activity calories, no distance
-        # no intensity minutes.
         dropkey = dic["Steps"] == 0
         if date in merged_data:
             if dropkey:
@@ -123,19 +117,13 @@ def merge_data(floors, calories, activities):
             else:
                 merged_data[date].update(dic)
         else:
-            merged_data[date] = dic
+            if not dropkey:
+                merged_data[date] = dic
 
     return dict(sorted(merged_data.items()))
 
 
 def write_to_file(data):
-    """
-    Write the data to a series of CSV files. We can only store a certain number of lines per file,
-    because if the files become too large, Garmin Connect will fail importing them.
-    Note: Garmin Connect might still show an error message. This does not mean the import failed.
-          Please check your data. The CSV files generated will be sorted by date, so when you go
-          back in time, you can easily check if your data is there or not.
-    """
     LINES_PER_FILE = 100
 
     dest = None
@@ -153,8 +141,12 @@ def write_to_file(data):
         "Activity Calories",
     ]
     for d in data:
-        # Add the date key to the row.
         data[d]["Date"] = d
+        # Default any missing fields to 0 to avoid empty cells
+        for col in columns:
+            if col not in data[d] or data[d][col] == "" or data[d][col] is None:
+                data[d][col] = 0
+
         if lines_written % LINES_PER_FILE == 0:
             filename = f"activities-export-{lines_written // LINES_PER_FILE + 1}.csv"
             if hasattr(dest, "close"):

--- a/exercises.py
+++ b/exercises.py
@@ -24,45 +24,48 @@ def ns3_tag(name):
 
 
 def fetch_exercise_list():
-    """
-    Fetch the list of exercises from Samsung's CSV file. The file contains general
-    data about each exercise, like the date and time, the calories burned or the duration.
-    The list also tells us, whether there is live data (e.g. heart rate) and/or location data
-    available.
-    """
-    exercise_files = glob.glob("com.samsung.shealth.exercise.*.csv")
+    exercise_files = glob.glob("com.samsung.shealth.exercise.20*.csv")
     if len(exercise_files) == 0:
         raise Exception("No exercise data found.")
     filename = exercise_files[0]
 
     prefix = "com.samsung.health.exercise."
-    fields = [
-        prefix + "datauuid",
-        prefix + "start_time",
-        "total_calorie",
-        prefix + "duration",
-        prefix + "exercise_type",
-        "heart_rate_sample_count",
-        prefix + "mean_heart_rate",
-        prefix + "max_heart_rate",
-        prefix + "min_heart_rate",
-        prefix + "mean_speed",
-        prefix + "max_speed",
-        prefix + "mean_cadence",
-        prefix + "max_cadence",
-        prefix + "distance",
-        prefix + "location_data",
-        prefix + "live_data",
+
+    # All these fields use the full prefix in this export
+    prefixed_fields = [
+        "datauuid",
+        "start_time",
+        "duration",
+        "exercise_type",
+        "mean_heart_rate",
+        "max_heart_rate",
+        "min_heart_rate",
+        "mean_speed",
+        "max_speed",
+        "mean_cadence",
+        "max_cadence",
+        "distance",
+        "location_data",
+        "live_data",
     ]
-    with open(filename, newline="") as exercise_list:
-        # Skip first line
-        next(exercise_list)
+
+    # These appear without prefix
+    bare_fields = {
+        "total_calorie": "total_calorie",
+        "heart_rate_sample_count": "heart_rate_sample_count",
+    }
+
+    # Open with utf-8-sig to strip the BOM
+    with open(filename, newline="", encoding="utf-8-sig") as exercise_list:
+        next(exercise_list)  # skip metadata line
         reader = csv.DictReader(exercise_list)
         data = []
         for row in reader:
             dataset = {}
-            for f in fields:
-                dataset[f.replace(prefix, "")] = row[f]
+            for f in prefixed_fields:
+                dataset[f] = row.get(prefix + f, "")
+            for src, dest in bare_fields.items():
+                dataset[dest] = row.get(src, "")
             data.append(dataset)
 
         return data
@@ -366,13 +369,6 @@ def merge_location_and_live_data(locationdata, livedata):
 
 
 def prepare_exercise_data(exercise):
-    """
-    Fetch and merge the data for the given exercise and create proper XML.
-    """
-
-    # The time code is used as the Id and StartTime for the lap. It is almost in the right format,
-    # we just need to add the T separator between the date and the time and append a Z for the UTC
-    # time zone.
     time = exercise["start_time"].replace(" ", "T") + "Z"
     ex_type = convert_activity_type(exercise["exercise_type"])
 
@@ -390,12 +386,21 @@ def prepare_exercise_data(exercise):
     )
 
     live_data = []
-    if ex["live_data"]:
-        live_data = fetch_live_data(ex["datauuid"])
+    live_data_val = exercise.get("live_data", "").strip()
+    # Value is either a filename, "0", or empty — treat anything with a UUID as present
+    if live_data_val and live_data_val != "0":
+        try:
+            live_data = fetch_live_data(exercise["datauuid"])
+        except Exception:
+            pass
 
     location_data = []
-    if ex["location_data"]:
-        location_data = fetch_location_data(ex["datauuid"])
+    location_data_val = exercise.get("location_data", "").strip()
+    if location_data_val and location_data_val != "0":
+        try:
+            location_data = fetch_location_data(exercise["datauuid"])
+        except Exception:
+            pass
 
     data = merge_location_and_live_data(location_data, live_data)
     trackpoints = []
@@ -415,6 +420,8 @@ def write_to_file(filename, xml):
 
 # We will generate quite a bunch of files, so it is better to have them all in one
 # subdir.
+# We will generate quite a bunch of files, so it is better to have them all in one
+# subdir.
 if not os.path.isdir("exports"):
     os.makedirs("exports")
 
@@ -422,10 +429,15 @@ print("Fetching exercises...", end="")
 exercises = fetch_exercise_list()
 print(f"done. Found {len(exercises)} exercises.")
 print("Preparing individual TCX files", end="")
+skipped = 0
 for ex in exercises:
-    print(".", end="", flush=True)
-    xml = prepare_exercise_data(ex)
-    date_code = ex["start_time"][0:10]
-    write_to_file(f"exports/{ex['exercise_type']}_{date_code}_{ex['datauuid']}.tcx", xml)
+    try:
+        print(".", end="", flush=True)
+        xml = prepare_exercise_data(ex)
+        date_code = ex["start_time"][0:10]
+        write_to_file(f"exports/{ex['exercise_type']}_{date_code}_{ex['datauuid']}.tcx", xml)
+    except Exception as e:
+        skipped += 1
+        print(f"\nSkipped {ex.get('datauuid','?')} ({ex.get('start_time','?')}): {e}")
 
-print("done")
+print(f"\ndone. Skipped {skipped} exercises.")

--- a/weight.py
+++ b/weight.py
@@ -17,26 +17,39 @@ def fetch_weight_data() -> List[Dict[str, float]]:
     filename = weight_files[0]
 
     weight_data = []
+    last_known_height = None
     with open(filename, newline="") as f:
         next(f)
         reader = csv.DictReader(f)
         for row in reader:
-            weight = float(row["weight"])
-            height = float(row["height"])
-            # If body fat is recorded, we will include it. However, Garmin Connect
-            # will not show it.
+            try:
+                weight = float(row["weight"])
+            except ValueError:
+                continue  # skip rows with no weight
+
+            # Use height from this row, or fall back to last known height
+            try:
+                height = float(row["height"])
+                if height > 0:
+                    last_known_height = height
+            except ValueError:
+                height = last_known_height
+
             try:
                 fat_mass = float(row["body_fat_mass"])
             except ValueError:
                 fat_mass = 0
 
+            bmi = round(weight / ((height / 100) ** 2), 2) if height else 0
+            fat_pct = round(fat_mass / weight * 100, 1) if fat_mass else 0
+
             weight_data.append(
                 {
                     "Date": row["start_time"][0:10],
                     "Weight": weight,
-                    "Height": height,
-                    "BMI": round(weight / ((height / 100) ** 2), 2),
-                    "Fat": round(fat_mass / weight * 100, 1),
+                    "Height": height if height else 0,
+                    "BMI": bmi,
+                    "Fat": fat_pct,
                 }
             )
 


### PR DESCRIPTION
Newer Samsung Health exports (tested on 2025–2026 exports) have several
schema differences that cause the original scripts to crash or silently
produce incorrect output. This PR fixes all three scripts to handle both
the old and new formats gracefully.

## Changes

### exercises.py
- Updated glob pattern to `com.samsung.shealth.exercise.20*.csv` to avoid
  matching sub-files (hr_zone, extension, weather, periodization_training_schedule)
  that share the same filename prefix
- Updated field mapping to handle exports where `datauuid` and `start_time`
  use the full `com.samsung.health.exercise.` column prefix
- Opened exercise CSV with `utf-8-sig` encoding to strip UTF-8 BOM present
  in newer exports
- Updated `live_data` and `location_data` detection: newer exports store a
  JSON filename in these fields rather than a `0`/`1` flag

### activity.py
- `day_time` in `com.samsung.shealth.activity.day_summary` is now a
  human-readable datetime string in newer exports rather than a Unix
  millisecond timestamp — script now handles both formats
- Fixed KeyError in `merge_data` when a date appears in floors data but
  not in calories data
- Missing `Floors` values (empty strings) are now defaulted to `0` before
  writing to prevent Garmin Connect import failures

### weight.py
- Script no longer crashes when `height` is empty (common for entries
  logged by third-party apps like MyFitnessPal)
- Carries forward last known height value for BMI calculation
- Skips rows with no weight value rather than raising ValueError

## Testing
Tested against a full Samsung Health export from June 2026, successfully
importing 3800+ exercise TCX files, 27 activity CSV batches, and weight
data dating back to 2018.